### PR TITLE
feat: updated to latest contract standards using lib.rs with entry function and release config

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "base64"
-version = "0.11.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "block-buffer"
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "mazzaroth-rs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d165aaaf2ab9978b149d4078ef3fed3ec50324fec5192b9ede1d160545ab9e"
+checksum = "cf934c901462bb1aa88097a8044f172f5fb42ecc5803f9431457db801fb5fce0"
 dependencies = [
  "cfg-if",
  "mazzaroth-xdr",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "mazzaroth-rs-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f99ea0c5cfb8aa4ca81dac6e02282e0f4954d5ba7110ac00d6178f27c09286"
+checksum = "9f53ff2d2abaa75adf9e7d8ccd33fc959d6cbbb04db06d7a343dacad440677ed"
 dependencies = [
  "mazzaroth-xdr",
  "proc-macro2 0.4.30",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "mazzaroth-xdr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673233600b1c05aaa448e6492e5d2430ab3e61d10bf7954cc215a2568515626d"
+checksum = "606eaec7c58ed54ce8c15a5633f5ef3797540c1d66893b7d35037e9cec64902f"
 dependencies = [
  "json",
  "xdr-rs-serialize",
@@ -165,16 +165,16 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -192,7 +192,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.47",
 ]
 
 [[package]]
@@ -216,18 +216,18 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.47",
  "quote 1.0.7",
- "unicode-xid 0.2.1",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -237,16 +237,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "wasm-bindgen"
@@ -267,9 +267,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.47",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -289,9 +289,9 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
- "proc-macro2 1.0.19",
+ "proc-macro2 1.0.47",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -304,9 +304,9 @@ checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "xdr-rs-serialize"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74e59c0da611180cb84c3a4bee415ad3104358bfae61a688a2167414b1770bd"
+checksum = "71b0d68af0b22a8be627a13d392e9d378f8f7f1f79543a09fddb5c97030a3749"
 dependencies = [
  "base64",
  "hex",
@@ -315,11 +315,11 @@ dependencies = [
 
 [[package]]
 name = "xdr-rs-serialize-derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28e2f52c4178318bc5e637879f6142bdd2097f7f73c7770a0204ebf45892a9a"
+checksum = "7abcd23270af2d44e3172a86a57aafee2c7b89f19513fefd86ade1433c75b286"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.47",
+ "quote 1.0.7",
+ "syn 1.0.103",
 ]

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -4,10 +4,20 @@ version = "0.1.0"
 authors = ["Kochavalabs"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
-mazzaroth-rs = "0.8.0"
-mazzaroth-rs-derive = "0.8.0"
+mazzaroth-rs = "0.8.1"
+mazzaroth-rs-derive = "0.8.1"
 xdr-rs-serialize = "0.3.0"
 xdr-rs-serialize-derive = "0.3.0"
-mazzaroth-xdr = "0.8.1"
+mazzaroth-xdr = "0.8.2"
 json = "0.12.0"
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+overflow-checks = true
+codegen-units = 1

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -7,13 +7,14 @@ extern crate xdr_rs_serialize_derive;
 pub mod xdr;
 
 use xdr_rs_serialize::ser::XDROut;
-
+ 
 use mazzaroth_rs::external::{sql, transaction};
 use mazzaroth_rs::ContractInterface;
 use mazzaroth_rs_derive::mazzaroth_abi;
 use xdr::*;
 
-pub fn main() {
+#[no_mangle]
+pub fn entry() {
     std::panic::set_hook(Box::new(mazzaroth_rs::external::errors::hook));
 
     // Creates a new instance of the ABI generated around the Contract
@@ -51,7 +52,7 @@ impl ExampleContract for Example {
         let tables = vec!["foo", "bar"];
         for table in &tables {
             match sql::exec(format!("CREATE TABLE {};", table)) {
-                Some(_) => panic!(format!("Error creating table {}", table)),
+                Some(_) => panic!("Error creating table {}", table),
                 None => {}
             };
         }

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -30,7 +30,7 @@ deploy:
                 "status": 1,
                 "one": "One",
                 "two": "Two",
-                "three": "Thre"
+                "three": "Three"
             }']
     - tx:
         function: "insert_foo"


### PR DESCRIPTION
# Description

Updated the contract to use latest Mazzaroth Contract standards.
- Using Rust library crate type with the "entry" function defined instead of "main".
- Updated the release profile configs to produce a more optimized contract binary.
- Fixed warnings and misspelling
